### PR TITLE
docs: Add blog post to make the Vercel build happy

### DIFF
--- a/blog/2023-03-13-quack.md
+++ b/blog/2023-03-13-quack.md
@@ -1,0 +1,17 @@
+---
+title: Quack
+description: quack quack
+slug: quack
+authors:
+  - name: Dakota Chambers
+    url: https://github.com/dcchambers
+tags: [hello, quack]
+hide_table_of_contents: true
+---
+
+```
+   __
+__( •)< quack
+\____)
+           
+```


### PR DESCRIPTION
Vercel was complaining about docusaurus build errors due to broken links. Throwing in a dummy blog post to get the build to pass.