### PR TITLE
docs: Add handbook page to projects and update deployment docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,12 +37,13 @@ This website is built using [Docusaurus 2](https://docusaurus.io/).
 
 ### Easy Local Dev
 
-You need node installed, then run
+Install node, then run
 ```sh
 npm run start
 ```
 
-The site launches at `https://localhost:3000`
+- The site launches at `https://localhost:3000` in your browser.
+- Live reloads changes.
 
 ### Installation
 
@@ -68,19 +69,10 @@ This command generates static content into the `build` directory and can be serv
 
 ### Deployment
 
-Using SSH:
-
-```
-$ USE_SSH=true yarn deploy
-```
-
-Not using SSH:
-
-```
-$ GIT_USER=<Your GitHub username> yarn deploy
-```
-
-If you are using GitHub pages for hosting, this command is a convenient way to build the website and push to the `gh-pages` branch.
+- [Vercel](https://vercel.com/digitalducky/handbook)
+- Deployed via the Vercel git Integration
+- Deploys to production automatically with new merges to `main`.
+- Deploys to preview automatically when a pull request is opened.
 
 [^1]: I would highly recommend reading more about the handbook philosophy at GitLab. See also:
     - https://about.gitlab.com/handbook/

--- a/docs/projects/handbook.md
+++ b/docs/projects/handbook.md
@@ -1,0 +1,21 @@
+# Handbook
+
+:::info
+The Handbook is deployed to **production**.
+
+**https://handbook.digitalducky.io**
+:::
+
+Yes, we consider our Handbook a project at Digital Ducky!
+In fact, it's our first publicly deployed project!
+
+## Resources
+
+- [GitHub Repo](https://github.com/digitalducky/handbook)
+
+## Deployment
+
+- [Vercel](https://vercel.com/digitalducky/handbook)
+- Deployed via the Vercel git Integration
+- Deploys to production automatically with new merges to `main`.
+- Deploys to preview automatically when a pull request is opened.

--- a/docs/projects/projects.md
+++ b/docs/projects/projects.md
@@ -1,8 +1,8 @@
-# Projects
+# All Projects
 
 ## Public Projects
 
-- [Handbook](https://github.com/digitalducky/handbook)
+- [Handbook](handbook.md)
 
 ## Secret Projects
 

--- a/sidebars.js
+++ b/sidebars.js
@@ -30,8 +30,9 @@ const sidebars = {
       items: ['engineering/engineering'],
     },
     {
-      type: 'doc',
-      id: 'projects/projects',
+      type: 'category',
+      label: 'Projects',
+      items: ['projects/projects', 'projects/handbook'],
     },
     {
       type: 'doc',


### PR DESCRIPTION
- Add `/projects/handbook`
- Add Projects dropdown to sidebar
- Add deployment info to README