### PR TITLE
fix(docs): Change edit url to the correct github link

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -43,14 +43,14 @@ const config = {
           // Please change this to your repo.
           // Remove this to remove the "edit this page" links.
           editUrl:
-            'https://github.com/digitalducky/handbook',
+            'https://github.com/digitalducky/handbook/tree/main/',
         },
         blog: {
           showReadingTime: true,
           // Please change this to your repo.
           // Remove this to remove the "edit this page" links.
           editUrl:
-            'https://github.com/digitalducky/handbook',
+            'https://github.com/digitalducky/handbook/tree/main/',
         },
         theme: {
           customCss: require.resolve('./src/css/custom.css'),


### PR DESCRIPTION
`https://github.com/digitalducky/handbook` ▶️ `https://github.com/digitalducky/handbook/tree/main/`